### PR TITLE
New package: python-keyring-5.4

### DIFF
--- a/srcpkgs/python-keyring/template
+++ b/srcpkgs/python-keyring/template
@@ -1,0 +1,40 @@
+# Template file for 'python-keyring'
+pkgname=python-keyring
+version=5.4
+revision=1
+noarch=yes
+wrksrc="keyring-${version}"
+build_style="python-module"
+python_versions="2.7 3.4"
+hostmakedepends="python-setuptools python3.4-setuptools"
+depends="python"
+pycompile_module="keyring"
+short_desc="Python2 interface to the system keyring service"
+maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
+license="MIT"
+homepage="http://pypi.python.org/packages/source/k/keyring/"
+distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
+checksum=45891cd0af4c4af70fbed7ec6e3964d0261c14188de9ab31030c9d02272e22d2
+
+pre_build() {
+	sed -e '/setuptools_scm/d' \
+		-e "s/use_scm_version=True,/version=\"${version}\",/" \
+		-i setup.py
+}
+
+post_install() {
+	vlicense README.rst LICENSE
+	rm ${DESTDIR}/usr/bin/keyring
+}
+
+python3.4-keyring_package() {
+	noarch=yes
+	pycompile_version="3.4"
+	pycompile_module="keyring"
+	depends="python3.4"
+	short_desc="${short_desc/Python2/Python3.4}"
+	pkg_install() {
+		vmove usr/lib/python3.4
+		vlicense README.rst LICENSE
+	}
+}

--- a/srcpkgs/python3.4-keyring
+++ b/srcpkgs/python3.4-keyring
@@ -1,0 +1,1 @@
+python-keyring


### PR DESCRIPTION
This is not a hard dependency so I could live without it. Distribution doesn't really come with a proper licence file: details are in the readme.